### PR TITLE
Add unit tests for gemini basic prompt

### DIFF
--- a/src/gemini/use_cases/basic-prompt.use-case.spec.ts
+++ b/src/gemini/use_cases/basic-prompt.use-case.spec.ts
@@ -1,0 +1,38 @@
+import { basicPromptUseCase } from './basic-prompt.use-case';
+import { BasicPromptDto } from '../dtos/basic-prompt.dto';
+import { GoogleGenAI } from '@google/genai';
+
+describe('basicPromptUseCase', () => {
+  it('should call generateContent and return the response text', async () => {
+    const generateContent = jest.fn().mockResolvedValue({ text: 'hola' });
+
+    const aiMock = {
+      models: { generateContent },
+    } as unknown as GoogleGenAI;
+
+    const dto: BasicPromptDto = { prompt: 'hola' };
+
+    const result = await basicPromptUseCase(aiMock, dto);
+
+    expect(result).toBe('hola');
+    expect(generateContent).toHaveBeenCalledWith({
+      model: 'gemini-2.0-flash',
+      contents: dto.prompt,
+      config: { systemInstruction: expect.any(String) },
+    });
+  });
+
+  it('should return an empty string when no text returned', async () => {
+    const generateContent = jest.fn().mockResolvedValue({});
+
+    const aiMock = {
+      models: { generateContent },
+    } as unknown as GoogleGenAI;
+
+    const dto: BasicPromptDto = { prompt: 'hola' };
+
+    const result = await basicPromptUseCase(aiMock, dto);
+
+    expect(result).toBe('');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for the `basicPromptUseCase` to check request creation and empty text handling

## Testing
- `npm run format`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684ba4518d34832081001dc140d344ac