### PR TITLE
Add TypeScript examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,4 +3,5 @@
 1. Clonar repositorio
 2. Crear `.env` basado en el `.env.template`
 3. Cambiar las variables de entorno
+4. Revisar la carpeta `examples` para ejemplos en TypeScript.
 # gemini_nest_js_api

--- a/examples/basicPrompt.example.ts
+++ b/examples/basicPrompt.example.ts
@@ -1,0 +1,21 @@
+
+/**
+ * Example calling the basic prompt endpoint.
+ */
+async function main(): Promise<void> {
+  const response = await fetch('http://localhost:3000/api/gemini/basic-prompt', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ prompt: 'Hello, Gemini!' }),
+  });
+
+  const text = await response.text();
+  console.log(text);
+}
+
+main().catch((error) => {
+  console.error(error);
+});
+

--- a/examples/basicPromptStream.example.ts
+++ b/examples/basicPromptStream.example.ts
@@ -1,0 +1,31 @@
+/**
+ * Example streaming the response from the basic prompt stream endpoint.
+ */
+async function main(): Promise<void> {
+  const response = await fetch('http://localhost:3000/api/gemini/basic-prompt-stream', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ prompt: 'Hello, Gemini!' }),
+  });
+
+  if (!response.body) {
+    console.error('No stream returned');
+    return;
+  }
+
+  const reader = response.body.getReader();
+  const decoder = new TextDecoder();
+
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    console.log(decoder.decode(value));
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+});
+


### PR DESCRIPTION
## Summary
- add `basicPrompt.example.ts`
- add `basicPromptStream.example.ts`
- mention examples directory in README

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_b_684ba58bd074832088031a5cac5c1e1f